### PR TITLE
11 - Tuple to Object

### DIFF
--- a/questions/00011-easy-tuple-to-object/template.ts
+++ b/questions/00011-easy-tuple-to-object/template.ts
@@ -1,1 +1,3 @@
-type TupleToObject<T extends readonly any[]> = any
+type TupleToObject<T extends readonly (string | number)[]> = {
+  [Property in T[number]]: Property
+}

--- a/questions/00011-easy-tuple-to-object/test-cases.ts
+++ b/questions/00011-easy-tuple-to-object/test-cases.ts
@@ -5,9 +5,21 @@ const tupleNumber = [1, 2, 3, 4] as const
 const tupleMix = [1, '2', 3, '4'] as const
 
 type cases = [
-  Expect<Equal<TupleToObject<typeof tuple>, { tesla: 'tesla'; 'model 3': 'model 3'; 'model X': 'model X'; 'model Y': 'model Y' }>>,
+  Expect<
+    Equal<
+      TupleToObject<typeof tuple>,
+      {
+        tesla: 'tesla'
+        'model 3': 'model 3'
+        'model X': 'model X'
+        'model Y': 'model Y'
+      }
+    >
+  >,
   Expect<Equal<TupleToObject<typeof tupleNumber>, { 1: 1; 2: 2; 3: 3; 4: 4 }>>,
-  Expect<Equal<TupleToObject<typeof tupleMix>, { 1: 1; '2': '2'; 3: 3; '4': '4' }>>,
+  Expect<
+    Equal<TupleToObject<typeof tupleMix>, { 1: 1; '2': '2'; 3: 3; '4': '4' }>
+  >,
 ]
 
 // @ts-expect-error


### PR DESCRIPTION
[Test]

```tsx
import type { Equal, Expect } from '@type-challenges/utils'

const tuple = ['tesla', 'model 3', 'model X', 'model Y'] as const
const tupleNumber = [1, 2, 3, 4] as const
const tupleMix = [1, '2', 3, '4'] as const

type cases = [
  Expect<
    Equal<
      TupleToObject<typeof tuple>,
      {
        tesla: 'tesla'
        'model 3': 'model 3'
        'model X': 'model X'
        'model Y': 'model Y'
      }
    >
  >,
  Expect<Equal<TupleToObject<typeof tupleNumber>, { 1: 1; 2: 2; 3: 3; 4: 4 }>>,
  Expect<
    Equal<TupleToObject<typeof tupleMix>, { 1: 1; '2': '2'; 3: 3; '4': '4' }>
  >,
]

// @ts-expect-error
type error = TupleToObject<[[1, 2], {}]>

```

[Answer]

```tsx
type TupleToObject<T extends readonly (string | number)[]> = {
  [Property in T[number]]: Property
}

```
