### PR TITLE
189 - Awaited

### DIFF
--- a/questions/00189-easy-awaited/template.ts
+++ b/questions/00189-easy-awaited/template.ts
@@ -1,6 +1,4 @@
-type MyAwaited<T extends Promise<any> | PromiseLike<any>> = T extends Promise<
-  infer U
->
+type MyAwaited<T extends PromiseLike<any>> = T extends Promise<infer U>
   ? U extends Promise<any>
     ? MyAwaited<U>
     : U

--- a/questions/00189-easy-awaited/template.ts
+++ b/questions/00189-easy-awaited/template.ts
@@ -1,1 +1,9 @@
-type MyAwaited<T> = any
+type IsPromise<P> = P extends Promise<infer K> ? IsPromise<K> : P
+
+type MyAwaited<T extends Promise<any> | PromiseLike<any>> = T extends Promise<
+  infer P
+>
+  ? IsPromise<P>
+  : T extends { then: (onfulfilled: (arg: infer K) => any) => any }
+  ? K
+  : never

--- a/questions/00189-easy-awaited/template.ts
+++ b/questions/00189-easy-awaited/template.ts
@@ -1,9 +1,9 @@
-type IsPromise<P> = P extends Promise<infer K> ? IsPromise<K> : P
-
 type MyAwaited<T extends Promise<any> | PromiseLike<any>> = T extends Promise<
-  infer P
+  infer U
 >
-  ? IsPromise<P>
-  : T extends { then: (onfulfilled: (arg: infer K) => any) => any }
+  ? U extends Promise<any>
+    ? MyAwaited<U>
+    : U
+  : T extends { then(onfulfilled: (arg: infer K) => any): any }
   ? K
   : never


### PR DESCRIPTION
[Test]

```tsx
import type { Equal, Expect } from '@type-challenges/utils'

type X = Promise<string>
type Y = Promise<{ field: number }>
type Z = Promise<Promise<string | number>>
type Z1 = Promise<Promise<Promise<string | boolean>>>
type T = { then: (onfulfilled: (arg: number) => any) => any }

type cases = [
  Expect<Equal<MyAwaited<X>, string>>,
  Expect<Equal<MyAwaited<Y>, { field: number }>>,
  Expect<Equal<MyAwaited<Z>, string | number>>,
  Expect<Equal<MyAwaited<Z1>, string | boolean>>,
  Expect<Equal<MyAwaited<T>, number>>,
]

// @ts-expect-error
type error = MyAwaited<number>

```

[Answer]

```tsx
type MyAwaited<T extends PromiseLike<any>> = T extends Promise<infer U>
  ? U extends Promise<any>
    ? MyAwaited<U>
    : U
  : T extends { then(onfulfilled: (arg: infer K) => any): any }
  ? K
  : never

```
